### PR TITLE
Set up React skeleton for classes 11 and 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+build
+.env
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "study-portal",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Study Portal</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import Class11 from './components/Class11';
+import Class12 from './components/Class12';
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <ul>
+          <li><Link to="/class11">Class 11</Link></li>
+          <li><Link to="/class12">Class 12</Link></li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/class11" element={<Class11 />} />
+        <Route path="/class12" element={<Class12 />} />
+        <Route path="/" element={<div>Welcome to the study portal</div>} />
+      </Routes>
+    </Router>
+  );
+}
+
+export default App;

--- a/src/components/ChapterList.js
+++ b/src/components/ChapterList.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ChapterList = ({ chapters }) => (
+  <ul>
+    {chapters.map((chapter, index) => (
+      <li key={index}>{chapter}</li>
+    ))}
+  </ul>
+);
+
+export default ChapterList;

--- a/src/components/Class11.js
+++ b/src/components/Class11.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ChapterList from './ChapterList';
+import { class11Chapters } from '../data/chapters';
+
+const Class11 = () => (
+  <div>
+    <h2>Class 11</h2>
+    {Object.entries(class11Chapters).map(([subject, chapters]) => (
+      <div key={subject}>
+        <h3>{subject}</h3>
+        <ChapterList chapters={chapters} />
+      </div>
+    ))}
+  </div>
+);
+
+export default Class11;

--- a/src/components/Class12.js
+++ b/src/components/Class12.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import ChapterList from './ChapterList';
+import { class12Chapters } from '../data/chapters';
+
+const Class12 = () => (
+  <div>
+    <h2>Class 12</h2>
+    {Object.entries(class12Chapters).map(([subject, chapters]) => (
+      <div key={subject}>
+        <h3>{subject}</h3>
+        <ChapterList chapters={chapters} />
+      </div>
+    ))}
+  </div>
+);
+
+export default Class12;

--- a/src/data/chapters.js
+++ b/src/data/chapters.js
@@ -1,0 +1,11 @@
+export const class11Chapters = {
+  Physics: ['Physical World', 'Units and Measurements', 'Motion in a Straight Line'],
+  Chemistry: ['Some Basic Concepts of Chemistry', 'Structure of Atom', 'Classification of Elements'],
+  Mathematics: ['Sets', 'Relations and Functions', 'Trigonometric Functions']
+};
+
+export const class12Chapters = {
+  Physics: ['Electric Charges and Fields', 'Electrostatic Potential and Capacitance', 'Current Electricity'],
+  Chemistry: ['Solutions', 'Electrochemistry', 'Chemical Kinetics'],
+  Mathematics: ['Relations and Functions', 'Inverse Trigonometric Functions', 'Matrices']
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- initialize a React project scaffold for a study portal covering class 11 and 12 chapters
- provide placeholder chapter lists and routing between class pages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `npm test` *(fails: sh: 1: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ee26b7ac832cb609abbf20aa160c